### PR TITLE
Fixed one liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sudo pacman -S curl git python3   # For Arch
 ```
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/debuggyo/Exo/main/exoinstall.py | python3 -
+curl -sSL https://raw.githubusercontent.com/debuggyo/Exo/main/exoinstall.py -o exoinstall.py && python3 exoinstall.py
 ```
 
 ## Updating and Uninstalling


### PR DESCRIPTION
Fixed one liner install command.
Piping data directly from curl to python3 was causing issue with handling user input