### PR TITLE
Add default keybinds missing from niri configuration

### DIFF
--- a/exodefaults/config.kdl
+++ b/exodefaults/config.kdl
@@ -106,6 +106,7 @@ binds {
     Mod+E { spawn "nautilus"; }
     Mod+Escape { spawn "ignis" "toggle-window" "PowerMenu"; }
     Mod+I { spawn "ignis" "toggle-window" "Settings"; }
+    Mod+A { spawn "ignis" "toggle-window" "QuickCenter"; }
 
     // Example volume keys mappings for PipeWire & WirePlumber.
     // The allow-when-locked=true property makes them work even when the session is locked.
@@ -113,6 +114,14 @@ binds {
     XF86AudioLowerVolume allow-when-locked=true { spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "0.1-"; }
     XF86AudioMute        allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
     XF86AudioMicMute     allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
+
+    XF86AudioNext         allow-when-locked=true { spawn-sh "playerctl next"; }
+    XF86AudioPause        allow-when-locked=true { spawn-sh "playerctl play-pause"; }
+    XF86AudioPlay         allow-when-locked=true { spawn-sh "playerctl play-pause"; }
+    XF86AudioPrev         allow-when-locked=true { spawn-sh "playerctl previous"; }
+    
+    XF86MonBrightnessUp   allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "+10%"; }
+    XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "10%-"; }
 
     Mod+Q { close-window; }
 
@@ -211,6 +220,8 @@ binds {
     // Move the focused window between the floating and the tiling layout.
     Mod+V       { toggle-window-floating; }
     Mod+Shift+V { switch-focus-between-floating-and-tiling; }
+
+    Mod+Tab { focus-workspace-previous; }
 
     Mod+Shift+S { screenshot show-pointer=false; }
     Ctrl+Print { screenshot-screen show-pointer=false; }

--- a/exodefaults/config.kdl
+++ b/exodefaults/config.kdl
@@ -97,7 +97,10 @@ binds {
     // shows a list of important hotkeys.
     Mod+Shift+Slash { show-hotkey-overlay; }
 
-    Mod+Grave { toggle-overview; }
+    // Open/close the Overview: a zoomed-out view of workspaces and windows.
+    // You can also move the mouse into the top-left hot corner,
+    // or do a four-finger swipe up on a touchpad.
+    Mod+O repeat=false { toggle-overview; }
 
     // Suggested binds for running programs: terminal, app launcher, screen locker.
     Mod+T { spawn "kitty"; }
@@ -115,15 +118,20 @@ binds {
     XF86AudioMute        allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
     XF86AudioMicMute     allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
 
+    // Example media keys mapping using playerctl.
+    // This will work with any MPRIS-enabled media player.
     XF86AudioNext         allow-when-locked=true { spawn-sh "playerctl next"; }
     XF86AudioPause        allow-when-locked=true { spawn-sh "playerctl play-pause"; }
     XF86AudioPlay         allow-when-locked=true { spawn-sh "playerctl play-pause"; }
     XF86AudioPrev         allow-when-locked=true { spawn-sh "playerctl previous"; }
-    
+
+    // Example brightness key mappings for brightnessctl.
+    // You can use regular spawn with multiple arguments too (to avoid going through "sh"),
+    // but you need to manually put each argument in separate "" quotes.
     XF86MonBrightnessUp   allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "+10%"; }
     XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "10%-"; }
 
-    Mod+Q { close-window; }
+    Mod+Q repeat=false { close-window; }
 
     Mod+Left  { focus-column-left; }
     Mod+Down  { focus-window-down; }

--- a/exodefaults/config.kdl
+++ b/exodefaults/config.kdl
@@ -98,8 +98,7 @@ binds {
     Mod+Shift+Slash { show-hotkey-overlay; }
 
     // Open/close the Overview: a zoomed-out view of workspaces and windows.
-    // You can also move the mouse into the top-left hot corner,
-    // or do a four-finger swipe up on a touchpad.
+    // You can also do a four-finger swipe up on a touchpad.
     Mod+O repeat=false { toggle-overview; }
 
     // Suggested binds for running programs: terminal, app launcher, screen locker.
@@ -126,8 +125,6 @@ binds {
     XF86AudioPrev         allow-when-locked=true { spawn-sh "playerctl previous"; }
 
     // Example brightness key mappings for brightnessctl.
-    // You can use regular spawn with multiple arguments too (to avoid going through "sh"),
-    // but you need to manually put each argument in separate "" quotes.
     XF86MonBrightnessUp   allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "+10%"; }
     XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "--class=backlight" "set" "10%-"; }
 


### PR DESCRIPTION
I noticed the default configuration set by Exo lacked a lot of keybinds that are in the default config file used by niri: https://raw.githubusercontent.com/YaLTeR/niri/refs/heads/main/resources/default-config.kdl
This PR reintroduces many of those.