### PR TITLE
matugen is not in path in fedora at least, this fixes it

### DIFF
--- a/exoinstall.py
+++ b/exoinstall.py
@@ -431,6 +431,8 @@ class ExoInstaller:
                     print(
                         f"{self.Colors.RED}Failed to install matugen via cargo.{self.Colors.ENDC}"
                     )
+                else:
+                    self.run_command(["export", "PATH=\"$PATH:~/.cargo/bin\""])
             elif self.distro == "ubuntu":
                 result = self.run_command(["sudo", "apt", "update"])
                 if result is None or (


### PR DESCRIPTION
This is a pretty small change and only fedora focused, because its the only distro i can test rn, basically matugen is not in path when installing which causes it to not generate initial coloring correctly

will change if it needs to be better