### PR TITLE
Use Material Icons Outlined as backup everywhere

### DIFF
--- a/ignis/modules/bar/widgets/media.py
+++ b/ignis/modules/bar/widgets/media.py
@@ -93,7 +93,7 @@ class Player(widgets.Box):
 
         self.play_pause_label = widgets.Label(
             css_classes=["overlay-icon"],
-            style="font-family: 'Material Symbols Outlined';",
+            style="font-family: 'Material Symbols Outlined', 'Material Icons Outlined';",
             halign="center",
             valign="center",
         )

--- a/ignis/styles/m3.scss
+++ b/ignis/styles/m3.scss
@@ -12,7 +12,7 @@ $square-radius: 12px;
 }
 
 .m3-icon {
-    font-family: "Material Symbols Outlined";
+    font-family: "Material Symbols Outlined", "Material Icons Outlined";
 }
 
 .m3-button {
@@ -26,7 +26,7 @@ $square-radius: 12px;
         line-height: 0px;
     }
     .m3-button-icon {
-        font-family: "Material Symbols Outlined";
+        font-family: "Material Symbols Outlined", "Material Icons Outlined";
     }
     .m3-button-label {
         color: colors.$on_background;
@@ -402,7 +402,7 @@ switch {
     border-radius: 24px;
     padding: 10px 16px;
     .m3-icon {
-        font-family: "Material Symbols Outlined";
+        font-family: "Material Symbols Outlined", "Material Icons Outlined";
         font-size: 1.5rem;
         color: colors.$on_surface;
         margin-right: 0px;


### PR DESCRIPTION
Modified the code a bit so it uses Material Icons Outlined as backup in all the files possible, tested on fedora 42 on niri and it works as expected