### PR TITLE
add missing deps on fedora

### DIFF
--- a/exoinstall.py
+++ b/exoinstall.py
@@ -350,6 +350,8 @@ class ExoInstaller:
                 "ninja-build",
                 "pkg-config",
                 "scdoc",
+                "nodejs-npm",
+                "python3-cairo-devel",
                 "libxkbcommon-devel",
                 "wayland-devel",
                 "libdisplay-info-devel",


### PR DESCRIPTION
I got this error
```
Installing ignis via pip...
Collecting git+https://github.com/ignis-sh/ignis.git
  Cloning https://github.com/ignis-sh/ignis.git to /tmp/pip-req-build-eu1ycw17
  Running command git clone --filter=blob:none --quiet https://github.com/ignis-sh/ignis.git /tmp/pip-req-build-eu1ycw17
  Resolved https://github.com/ignis-sh/ignis.git to commit 57017f8fbde4c4c67bdd4fa69c72589358882928
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: click>=8.1.7 in /usr/lib/python3.13/site-packages (from ignis==0.5.post1.dev149+g57017f8fb) (8.1.7)
Collecting loguru>=0.7.2 (from ignis==0.5.post1.dev149+g57017f8fb)
  Downloading loguru-0.7.3-py3-none-any.whl.metadata (22 kB)
Collecting pycairo>=1.26.1 (from ignis==0.5.post1.dev149+g57017f8fb)
  Downloading pycairo-1.28.0.tar.gz (662 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 662.5/662.5 kB 4.5 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [49 lines of output]
      + meson setup /tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f /tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f/.mesonpy-va49anb1 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md -Dwheel=true -Dtests=false --native-file=/tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f/.mesonpy-va49anb1/meson-python-native-file.ini
      The Meson build system
      Version: 1.9.1
      Source dir: /tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f
      Build dir: /tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f/.mesonpy-va49anb1
      Build type: native build
      Project name: pycairo
      Project version: 1.28.0
      C compiler for the host machine: cc (gcc 15.2.1 "cc (GCC) 15.2.1 20250808 (Red Hat 15.2.1-1)")
      C linker for the host machine: cc ld.bfd 2.44-6
      Host machine cpu family: x86_64
      Host machine cpu: x86_64
      Program python3 found: YES (/usr/bin/python3)
      Compiler for C supports arguments -Wall: YES
      Compiler for C supports arguments -Warray-bounds: YES
      Compiler for C supports arguments -Wcast-align: YES
      Compiler for C supports arguments -Wconversion: YES
      Compiler for C supports arguments -Wextra: YES
      Compiler for C supports arguments -Wformat=2: YES
      Compiler for C supports arguments -Wformat-nonliteral: YES
      Compiler for C supports arguments -Wformat-security: YES
      Compiler for C supports arguments -Wimplicit-function-declaration: YES
      Compiler for C supports arguments -Winit-self: YES
      Compiler for C supports arguments -Winline: YES
      Compiler for C supports arguments -Wmissing-format-attribute: YES
      Compiler for C supports arguments -Wmissing-noreturn: YES
      Compiler for C supports arguments -Wnested-externs: YES
      Compiler for C supports arguments -Wold-style-definition: YES
      Compiler for C supports arguments -Wpacked: YES
      Compiler for C supports arguments -Wpointer-arith: YES
      Compiler for C supports arguments -Wreturn-type: YES
      Compiler for C supports arguments -Wshadow: YES
      Compiler for C supports arguments -Wsign-compare: YES
      Compiler for C supports arguments -Wstrict-aliasing: YES
      Compiler for C supports arguments -Wundef: YES
      Compiler for C supports arguments -Wunused-but-set-variable: YES
      Compiler for C supports arguments -Wswitch-default: YES
      Compiler for C supports arguments -Wno-missing-field-initializers: YES
      Compiler for C supports arguments -Wno-unused-parameter: YES
      Compiler for C supports arguments -fno-strict-aliasing: YES
      Compiler for C supports arguments -fvisibility=hidden: YES
      Found pkg-config: YES (/usr/bin/pkg-config) 2.3.0
      Did not find CMake 'cmake'
      Found CMake: NO
      Run-time dependency cairo found: NO (tried pkgconfig)
      
      ../cairo/meson.build:31:12: ERROR: Dependency "cairo" not found, tried pkgconfig
      
      A full log can be found at /tmp/pip-install-4lda3ubf/pycairo_60a15320ec90490083a7e425d891a86f/.mesonpy-va49anb1/meson-logs/meson-log.txt
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Error executing command: Command '['pip', 'install', '--user', 'git+https://github.com/ignis-sh/ignis.git']' returned non-zero exit status 1.
Failed to install ignis via pip.
```
so I need to add `python3-cairo-devel` to fix it.