### PR TITLE
Fix hyprland.conf detection

### DIFF
--- a/exoinstall.py
+++ b/exoinstall.py
@@ -750,7 +750,7 @@ class ExoInstaller:
 
         if desktop_env in ["hyprland", "both"]:
             print("Copying Hyprland config...")
-            hypr_config_dir = os.path.join(self.config_dir, "hypr", "hyprland")
+            hypr_config_dir = os.path.join(self.config_dir, "hypr")
             os.makedirs(hypr_config_dir, exist_ok=True)
             hypr_source = os.path.join(self.source_dir, "exodefaults", "hyprland.conf")
             hypr_dest = os.path.join(hypr_config_dir, "hyprland.conf")


### PR DESCRIPTION
I don't do programming at all but this is probably how you fix it

Hyprland configuration file location is `.config/hypr/hyprland.conf` and NOT `.config/hypr/hyprland/hyprland.conf`.
This fixes exo installer to correctly detect pre-existing hyprland configuration and act accordingly.

...also consider allowing people to not delete all or some configuration files in the uninstallation process, hence "skip" option exists and forcing config file removal can cause some inconveniences from that